### PR TITLE
make topic subname a param for remapping

### DIFF
--- a/include/optitrack/optitrack.h
+++ b/include/optitrack/optitrack.h
@@ -42,6 +42,7 @@ namespace optitrack {
     std::string localIP_;     ///< IP addr of local NIC to use.
     std::string serverIP_;    ///< IP addr of server (for commands)
     std::string multicastIP_; ///< Multicast group (for UDP data)
+    std::string topicSubname_;///< /<veh>/<subname>: used for remapping
     int commandPort_;         ///< Port used for sending cmds to server
     int dataPort_;            ///< Port used for multicast data from server
     bool pubResiduals_;       ///< Publish rigid body residual (quality metric)

--- a/launch/optitrack.launch
+++ b/launch/optitrack.launch
@@ -7,6 +7,9 @@
     <arg name="data_port" default="1511" />
     <arg name="pub_residuals" default="false" />
 
+    <!-- (e.g., "/<vehicle>/<topic_subname>") -->
+    <arg name="topic_subname" default="world" />
+
     <node pkg="optitrack" type="optitrack" name="optitrack" output="screen">
         <param name="local" value="$(arg local)" />
         <param name="server" value="$(arg server)" />
@@ -14,6 +17,7 @@
         <param name="command_port" value="$(arg command_port)" />
         <param name="data_port" value="$(arg data_port)" />
         <param name="pub_residuals" value="$(arg pub_residuals)" />
+        <param name="topic_subname" value="$(arg topic_subname)" />
     </node>
 
 </launch>

--- a/src/optitrack.cpp
+++ b/src/optitrack.cpp
@@ -19,6 +19,7 @@ OptiTrack::OptiTrack(const ros::NodeHandle nh)
   nh.getParam("command_port", commandPort_);
   nh.getParam("data_port", dataPort_);
   nh.getParam("pub_residuals", pubResiduals_);
+  nh.param<std::string>("topic_subname", topicSubname_, "world");
 
   client_ = std::make_unique<agile::OptiTrackClient>(localIP_, serverIP_, multicastIP_, commandPort_, dataPort_);
 
@@ -80,7 +81,7 @@ void OptiTrack::spin()
 
         ROS_WARN_STREAM("Found '" << name << "'");
 
-        std::string topic = "/" + name + "/optitrack";
+        std::string topic = "/" + name + "/" + topicSubname_;
         pubs_pose_[pkt.rigid_body_id] = nh_.advertise<geometry_msgs::PoseStamped>(topic, 1);
 
         if (pubResiduals_) {
@@ -102,6 +103,7 @@ void OptiTrack::spin()
 
       // Add timestamp
       geometry_msgs::PoseStamped currentState;
+      currentState.header.frame_id = "optitrack";
       currentState.header.stamp = ros::Time(packet_ntime/1e9, packet_ntime%(int64_t)1e9);
 
       // convert from raw optitrack frame to ENU with body flu


### PR DESCRIPTION
the `topic_subname` argument/param can be used to remap all vehicles. By default, a `PoseStamped` gets published to `/HX02/world`. But if you wanted to record data from vicon and optitrack at the same time, you could use `topic_subname:=optitrack` to remap to `/HX02/optitrack`.